### PR TITLE
Use Newtonsoft.Json instead of Microsoft.JScript to extract MSDN short id for docs.

### DIFF
--- a/SharpGen/SharpGen.csproj
+++ b/SharpGen/SharpGen.csproj
@@ -61,9 +61,11 @@
       <HintPath>..\packages\ICSharpCode.SharpZipLib.Patched.0.86.5\lib\net20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.JScript" />
     <Reference Include="Mono.Options, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Options.5.3.0\lib\net4-client\Mono.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SharpGen/packages.config
+++ b/SharpGen/packages.config
@@ -3,4 +3,5 @@
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net40" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net40" />
   <package id="Mono.Options" version="5.3.0" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Changed DocProviderMsdn to use Newtonsoft.Json to extract the short id instead of Microsoft.JScript as a start towards making SharpGen possibly buildable in .NET Core (as well as making sure that it is impossible for malicious javascript to be injected since we are now parsing as JSON instead of Javascript).