### PR TITLE
Early guard if AppType is not present in command line

### DIFF
--- a/SharpGen/CodeGenApp.cs
+++ b/SharpGen/CodeGenApp.cs
@@ -148,6 +148,8 @@ namespace SharpGen
 
             if (_configRootPath == null)
                 UsageError("Missing config.xml. A config.xml must be specified");
+            if (AppType == null)
+                UsageError("Missing apptype argument. an App type must be specified (for example: -apptype=DESKTOP_APP");
         }
 
         /// <summary>


### PR DESCRIPTION
Hello, this is just a small one, but generation fails quite late in the process if apptype is not specified (give some null reference on path combine), which makes it quite hard to debug.

I just added a check on the command line options parsing, so user can have a more meaningful error message straight away.

As a side note, there could be an option to ignore apptype altogether (in some cases importing desktop only libraries, so that feels one step that is not required)

Thanks